### PR TITLE
Report type of errors in summary

### DIFF
--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -865,11 +865,15 @@ class PotentialBuild
     test_results_total = 0
     test_results_warning = 0
 
+    test_results_failure_counts= {}
+    test_results_failure_counts.default=0
+
     if !@test_results.nil?
       @test_results.each { |t| 
         test_results_total += 1
         test_results_passed += 1 if t.passed
         test_results_warning += 1 if t.warning
+        test_results_failure_counts[t.failure_type] += 1 if !t.passed
 
         test_results_data << t.inspect;
       }
@@ -1092,6 +1096,12 @@ eos
 
     $logger.debug("Message counts string: #{message_counts_str}")
 
+    test_results_failure_counts_str = ""
+    test_results_failure_counts.each{ |failure, count|
+      test_results_failure_counts_str += " * #{count} #{failure == "Failed" ? "General" : failure}\n"
+    }
+
+
     if !@failure.nil?    
       github_document = 
 <<-eos
@@ -1102,10 +1112,15 @@ eos
 <<-eos
 #{@refspec} (#{@author}) - #{device_id compiler}: #{github_status_message}
 
+#{message_counts_str == "" ? "" : "Messages:\n"}
 #{message_counts_str}
+#{test_results_failure_counts_str == "" ? "" : "Failures:\n"}
+#{test_results_failure_counts_str}
 
 #{build_badge} #{test_badge} #{coverage_badge}
 eos
+
+
     end
 
     if !@test_run

--- a/lib/resultsprocessor.rb
+++ b/lib/resultsprocessor.rb
@@ -442,13 +442,23 @@ module ResultsProcessor
                 nm = r["NamedMeasurement"]
 
                 if !nm.nil?
+                  failure_type = ""
+                  nm.each { |measurement|
+                    if measurement["name"] == "Exit Code"
+                      ft = measurement["Value"]
+                      if !ft.nil?
+                        failure_type = ft
+                      end
+                    end
+                  }
+
                   nm.each { |measurement|
                     if measurement["name"] == "Execution Time"
                       status_string = n["Status"]
                       if !value.nil? && value =~ /\[decent_ci:test_result:warn\]/ && status_string == "passed"
                         status_string = "warning" 
                       end
-                      results << TestResult.new(n["Name"], status_string, measurement["Value"], value, errors);
+                      results << TestResult.new(n["Name"], status_string, measurement["Value"], value, errors, failure_type);
                     end
                   }
                 end

--- a/lib/testresult.rb
+++ b/lib/testresult.rb
@@ -14,12 +14,13 @@ require 'base64'
 
 # Parsed test results for reporting back
 class TestResult
-  def initialize(name, status, time, output, parsed_errors)
+  def initialize(name, status, time, output, parsed_errors, failure_type)
     @name = name
     @status = status
     @time = time
     @output = output
     @parsed_errors = parsed_errors
+    @failure_type = failure_type
   end
 
   def passed
@@ -28,6 +29,10 @@ class TestResult
 
   def warning
     return @status == "warning"
+  end
+
+  def failure_type
+    return @failure_type
   end
 
   def inspect
@@ -43,7 +48,8 @@ class TestResult
       :status => @status,
       :time => @time,
       :output => @output,
-      :parsed_errors => parsed_errors_array
+      :parsed_errors => parsed_errors_array,
+      :failure_type => @failure_type
       }
     return hash
   end

--- a/lib/testresult.rb
+++ b/lib/testresult.rb
@@ -35,6 +35,10 @@ class TestResult
     return @failure_type
   end
 
+  def name
+    return @name
+  end
+
   def inspect
     parsed_errors_array = []
 


### PR DESCRIPTION
Addressing this issue:

> The error summary shall include an itemization of the number of crashes, number of fatal
> errors, number of unit test failures, and a list of all other failure conditions

Example error summary comment / email from github:

-------------------------------------
Messages:

 * 1 test had: A Message

Failures:

 * 1 General
 * 1 SEGFAULT
 * 1 Timeout
------------------------------------

Tested via decent_ci test project: https://github.com/lefticus/cpp_project_with_errors/tree/buildable_with_test_errors