### PR TITLE
Add ability to keep build folder, s3 retries

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -66,6 +66,8 @@ $logger.debug "Logging to decent_ci.log"
 options = {}
 options[:delay_after_run] = 300
 options[:maximum_branch_age] = 30
+options[:verbose] = false
+options[:keep_build_folder] = false
 
 opts = OptionParser.new do |opts|
   opts.banner = "Usage: #{__FILE__} [options] <testruntrueorfalse> <githubtoken> <repositoryname> (<repositoryname> ...)"
@@ -77,6 +79,11 @@ opts = OptionParser.new do |opts|
   opts.on("-s", "--disable-ssl-verification", "Disable verification of ssl certificates") do |v|
     options[:disable_ssl_verification] = v
   end
+
+  opts.on("--keep-build-folder", "Do not delete build folder after build completes") do |v|
+    options[:keep_build_folder] = v
+  end
+
 
   opts.on("--aws-access-key-id=[key]") do |k|
     ENV["AWS_ACCESS_KEY_ID"] = k
@@ -312,6 +319,7 @@ for conf in 2..ARGV.length-1
             # reset potential build for the next build attempt
             p.next_build
             p.set_test_run test_mode
+            p.set_keep_build_folder options[:keep_build_folder]
 
             if p.needs_run compiler
               $logger.info "Beginning build for #{compiler} #{p.descriptive_string}"
@@ -321,6 +329,8 @@ for conf in 2..ARGV.length-1
 
                 if p.needs_regression_test(compiler) && regression_base
                   regression_base.set_test_run test_mode
+                  regression_base.set_keep_build_folder options[:keep_build_folder]
+
                   p.clone_regression_repository compiler
                   regression_baselines << [compiler, regression_base];
 

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -76,6 +76,7 @@ class PotentialBuild
     @dateprefix = nil
     @failure = nil
     @test_run = false
+    @keep_build_folder = false
     @build_time = nil
     @test_time = nil
     @install_time = nil
@@ -110,6 +111,10 @@ class PotentialBuild
 
   def set_test_run new_test_run
     @test_run = new_test_run
+  end
+
+  def set_keep_build_folder new_keep_build_folder
+    @keep_build_folder = new_keep_build_folder
   end
 
   def descriptive_string
@@ -614,7 +619,7 @@ class PotentialBuild
 
 
   def clean_up compiler
-    if !@test_run
+    if !@test_run && !@keep_build_folder
       @created_dirs.each { |d|
         try_hard_to_remove_dir d
       }
@@ -622,7 +627,7 @@ class PotentialBuild
   end
 
   def clean_up_regressions compiler
-    if !@test_run
+    if !@test_run && !@keep_build_folder
       @created_regression_dirs.each { |d|
         try_hard_to_remove_dir d
       }

--- a/send_to_s3.py
+++ b/send_to_s3.py
@@ -8,35 +8,49 @@ import sys
 import os
 import datetime
 
-conn = boto.connect_s3();
-bucketname = sys.argv[1]
-bucket = conn.get_bucket(bucketname)
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
-buildname = sys.argv[2]
-sourcedir = sys.argv[3]
-destdir = sys.argv[4]
-
-filedir = "{0}/{1}-{2}".format(destdir, datetime.datetime.now().date().isoformat(), buildname);
-
-
-for root, subFolders, files in os.walk(sourcedir):
-    for file in files:
-        filename = os.path.join(root,file)
-        filepath = "{0}/{1}".format(filedir, os.path.relpath(filename, sourcedir))
-        print("{0} => {1}".format(filename, filepath), file=sys.stderr)
-        key = boto.s3.key.Key(bucket, filepath)
-        file_to_send = open(filename, 'r')
-        if (filepath.endswith(".html")):
-            content_type = {"Content-Type": "text/html"}
-        elif (filepath.endswith(".svg")):
-            content_type = {"Content-Type": "image/svg+xml"}
-        else:
-            content_type = {"Content-Type": "application/octect-stream"}
-
-        key.set_contents_from_string(file_to_send.read(), headers=content_type)
-        key.make_public()
+try:
+    try:
+        conn = boto.connect_s3()
+    except Exception as e:
+        eprint("Error connecting to s3, trying again: {0}".format(e))
+        conn = boto.connect_s3()
 
 
-print("http://{0}.s3-website-{1}.amazonaws.com/{2}".format(bucketname, "us-east-1", filedir))
+
+    bucketname = sys.argv[1]
+    bucket = conn.get_bucket(bucketname)
+
+    buildname = sys.argv[2]
+    sourcedir = sys.argv[3]
+    destdir = sys.argv[4]
+
+    filedir = "{0}/{1}-{2}".format(destdir, datetime.datetime.now().date().isoformat(), buildname);
+
+
+    for root, subFolders, files in os.walk(sourcedir):
+        for file in files:
+            filename = os.path.join(root,file)
+            filepath = "{0}/{1}".format(filedir, os.path.relpath(filename, sourcedir))
+            print("{0} => {1}".format(filename, filepath), file=sys.stderr)
+            key = boto.s3.key.Key(bucket, filepath)
+            file_to_send = open(filename, 'r')
+            if (filepath.endswith(".html")):
+                content_type = {"Content-Type": "text/html"}
+            elif (filepath.endswith(".svg")):
+                content_type = {"Content-Type": "image/svg+xml"}
+            else:
+                content_type = {"Content-Type": "application/octect-stream"}
+
+            key.set_contents_from_string(file_to_send.read(), headers=content_type)
+            key.make_public()
+
+
+    print("http://{0}.s3-website-{1}.amazonaws.com/{2}".format(bucketname, "us-east-1", filedir))
+
+except Exception as e:
+    print("Error uploading files: {0}".format(e))
 
 


### PR DESCRIPTION
Changes:

 - `--keep-build-folder` command line parameter which does not attempt to delete build folder after the execution has completed
 - Attempts to retry 1 time for s3 connection, if it fails it returns an error string instead of a valid URL for the upload link

Note that s3 changes are currently untested