### PR TITLE
Attempt to robustify the processing of stdout and stderr

### DIFF
--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -214,11 +214,11 @@ class PotentialBuild
         stdout, stderr, result = run_with_timeout(env, cmd, 60*60*6)
       end
 
-      stdout.encode('UTF-8',:invalid=>:replace).split("\n").each { |l| 
+      stdout.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l| 
         $logger.debug("cmd: #{cmd}: stdout: #{l}")
       }
 
-      stderr.encode('UTF-8',:invalid=>:replace).split("\n").each { |l| 
+      stderr.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l| 
         $logger.info("cmd: #{cmd}: stderr: #{l}")
       }
 

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -214,13 +214,21 @@ class PotentialBuild
         stdout, stderr, result = run_with_timeout(env, cmd, 60*60*6)
       end
 
-      stdout.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l| 
-        $logger.debug("cmd: #{cmd}: stdout: #{l}")
-      }
+      begin
+        stdout.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l|
+          $logger.debug("cmd: #{cmd}: stdout: #{l}")
+        }
+      rescue
+        $logger.debug("ERROR cmd: #{cmd}: stdout could not be parsed due to an encoding problem")
+      end
 
-      stderr.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l| 
-        $logger.info("cmd: #{cmd}: stderr: #{l}")
-      }
+      begin
+        stderr.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l|
+          $logger.info("cmd: #{cmd}: stderr: #{l}")
+        }
+      rescue
+        $logger.debug("ERROR cmd: #{cmd}: stderr could not be parsed due to an encoding problem")
+      end
 
       if cmd != commands.last && result != 0
         $logger.error("Error running script command: #{stderr}")

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -206,8 +206,8 @@ class PotentialBuild
     allresult = 0
 
     commands.each { |cmd|
-      if @config.os == "Windows"
-        $logger.warn "Unable to set timeout for process execution on windows"
+      if @config.os == 'Windows'
+        $logger.warn 'Unable to set timeout for process execution on windows'
         stdout, stderr, result = Open3::capture3(env, cmd)
       else
         # allow up to 6 hours
@@ -215,7 +215,7 @@ class PotentialBuild
       end
 
       begin
-        stdout.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l|
+        stdout.encode('UTF-8', invalid: :replace, undef: :replace, replace: '').split("\n").each { |l|
           $logger.debug("cmd: #{cmd}: stdout: #{l}")
         }
       rescue
@@ -223,7 +223,7 @@ class PotentialBuild
       end
 
       begin
-        stderr.encode('UTF-8',:invalid=>:replace, undef: :replace, replace: '').split("\n").each { |l|
+        stderr.encode('UTF-8', invalid: :replace, undef: :replace, replace: '').split("\n").each { |l|
           $logger.info("cmd: #{cmd}: stderr: #{l}")
         }
       rescue


### PR DESCRIPTION
We are still seeing UTF errors for invalid characters (invalid byte sequence in UTF-8 ["/home/el...)
I found a post (https://robots.thoughtbot.com/fight-back-utf-8-invalid-byte-sequences) that included some additional arguments to the encode call.  I think maybe the `undef:` argument would help when there are some stray characters in stdout.  These characters may be in the LaTeX, or somehow from the EnergyPlus input file, but regardless I think this would help it.

So this is still happening.  I'm thinking I'll also wrap the call inside a begin-rescue to really make sure we can handle the situation gracefully, and maybe figure out what's going on along the way.

@lefticus I don't know if you would want this protection in the master branch or not.  If you think it's OK to add it once I get the begin-rescue in place, go ahead and merge.  Otherwise I might point the E+ repo to this branch of decent_ci (I think I can do that...).